### PR TITLE
Setting/react query5

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,8 @@
 {
-  "extends": ["next/core-web-vitals", "prettier"]
+  "plugins": ["eslint-plugin-simple-import-sort"],
+  "extends": ["next/core-web-vitals", "prettier"],
+  "rules": {
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error"
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,8 @@
   "extends": ["next/core-web-vitals", "prettier"],
   "rules": {
     "simple-import-sort/imports": "error",
-    "simple-import-sort/exports": "error"
+    "simple-import-sort/exports": "error",
+    "no-unused-vars": "error",
+    "no-console": "warn"
   }
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,29 @@
+"use client" // Error components must be Client Components
+
+import { useEffect } from "react"
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    console.error(error)
+  }, [error])
+
+  return (
+    <div>
+      <h2>전역 error page</h2>
+      <button
+        onClick={
+          // Attempt to recover by trying to re-render the segment
+          () => reset()
+        }>
+        Try again
+      </button>
+    </div>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,9 @@
+import "@/styles/main.css"
+
 import type { Metadata } from "next"
 import localFont from "next/font/local"
-import "@/styles/main.css"
+
+import Providers from "../components/providers"
 
 const pretendard = localFont({
   src: "../font/PretendardVariable.woff2",
@@ -20,7 +23,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko" className={`${pretendard.variable}`}>
-      <body className={pretendard.className}>{children}</body>
+      <body className={pretendard.className}>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   )
 }

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,5 @@
+const Loading = () => {
+  return <div>전역 loding...</div>
+}
+
+export default Loading

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,10 @@
+import ErrorHandlingWrapper from "@/components/ErrorHandlingWrapper"
+import Test from "@/components/Test"
+
 export default function Home() {
-  return <main>Greeting! 👋 TEST</main>
+  return (
+    <ErrorHandlingWrapper>
+      <Test />
+    </ErrorHandlingWrapper>
+  )
 }

--- a/src/app/test/layout.tsx
+++ b/src/app/test/layout.tsx
@@ -1,0 +1,10 @@
+const TestLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div>
+      <header>header</header>
+      {children}
+    </div>
+  )
+}
+
+export default TestLayout

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from "react"
+
+import ErrorHandlingWrapper from "@/components/ErrorHandlingWrapper"
+import Test from "@/components/Test"
+
+const TestPage = () => {
+  return (
+    // 각 페이지마다 ErrorHandlingWrapper로 감싸줍니다.
+    // react-query의 QueryErrorResetBoundary를 이용하여 에러가 발생했을 때, 에러를 잡아주고 에러가 발생했을 때 보여줄 컴포넌트를 정의합니다.
+    <ErrorHandlingWrapper>
+      <Suspense fallback={<div>특정 범위 loading...</div>}>
+        <Test />
+      </Suspense>
+    </ErrorHandlingWrapper>
+  )
+}
+export default TestPage

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { Component, ComponentType, ErrorInfo, ReactNode } from "react"
+
+interface ErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+export interface FallbackProps {
+  error: Error | null
+  resetErrorBoundary: () => void
+}
+
+type ErrorBoundaryProps = {
+  FallbackComponent: ComponentType<FallbackProps>
+  onReset: () => void
+  children: ReactNode
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+
+    this.state = {
+      hasError: false,
+      error: null,
+    }
+
+    this.resetErrorBoundary = this.resetErrorBoundary.bind(this)
+  }
+
+  /** 에러 상태 변경 */
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.log({ error, errorInfo })
+  }
+
+  /** 에러 상태 기본 초기화 */
+  resetErrorBoundary(): void {
+    this.props.onReset()
+
+    this.setState({
+      hasError: false,
+      error: null,
+    })
+  }
+
+  render() {
+    const { state, props } = this
+
+    const { hasError, error } = state
+
+    const { FallbackComponent, children } = props
+
+    if (hasError && error) {
+      return (
+        <FallbackComponent
+          error={error}
+          resetErrorBoundary={this.resetErrorBoundary}
+        />
+      )
+    }
+
+    return children
+  }
+}
+
+export default ErrorBoundary

--- a/src/components/ErrorHandlingWrapper.tsx
+++ b/src/components/ErrorHandlingWrapper.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { QueryErrorResetBoundary } from "@tanstack/react-query"
+import { ComponentType } from "react"
+
+import ErrorBoundary, { FallbackProps } from "./ErrorBoundary"
+
+interface PropsType {
+  children: React.ReactNode
+}
+
+const FallbackComponent: ComponentType<FallbackProps> = ({
+  resetErrorBoundary,
+}) => (
+  <div>
+    There was an error!
+    <button onClick={() => resetErrorBoundary()}>Try again</button>
+  </div>
+)
+
+export default function ErrorHandlingWrapper({ children }: PropsType) {
+  return (
+    // query error reset boundary를 이용하여 에러가 발생했을 때, 에러를 잡아주고 에러가 발생했을 때 보여줄 컴포넌트를 정의합니다.
+    // query reset을 이용하여 에러가 발생했을 때, 에러를 초기화합니다.
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary onReset={reset} FallbackComponent={FallbackComponent}>
+          {children}
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  )
+}

--- a/src/components/Test.tsx
+++ b/src/components/Test.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useSuspenseQuery } from "@tanstack/react-query"
+
+const fetching = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 700))
+
+  let res
+  try {
+    res = await fetch("https://jsonplaceholder.typicode.com/todo/1")
+  } catch (error) {
+    throw error
+  }
+
+  const data = await res.json()
+  if (res.ok) return data
+  throw new Error(data)
+}
+
+const Test = () => {
+  // useSuspenseQuery는 useQuery와 비슷하지만, Suspense를 사용하여 데이터를 가져옵니다.
+  // 즉 useSuspenseQuery를 이용하여 데이터 패칭 시, 로딩 중일 경우 loading.tsx에 정의된 로딩 컴포넌트를 보여줍니다.
+  const { data } = useSuspenseQuery({
+    queryKey: ["test", "s"],
+    queryFn: () => fetching(),
+  })
+
+  return <div>get list....{data?.title}</div>
+}
+
+export default Test

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,0 @@
-// component exports

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,0 +1,51 @@
+// In Next.js, this file would be called: app/providers.jsx
+"use client"
+
+// Since QueryClientProvider relies on useContext under the hood, we have to put 'use client' on top
+import {
+  isServer,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query"
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        // With SSR, we usually want to set some default staleTime
+        // above 0 to avoid refetching immediately on the client
+        staleTime: 60 * 1000,
+        throwOnError: true,
+        retry: 0,
+      },
+    },
+  })
+}
+
+let browserQueryClient: QueryClient | undefined = undefined
+
+function getQueryClient() {
+  if (isServer) {
+    // Server: always make a new query client
+    return makeQueryClient()
+  } else {
+    // Browser: make a new query client if we don't already have one
+    // This is very important, so we don't re-make a new client if React
+    // suspends during the initial render. This may not be needed if we
+    // have a suspense boundary BELOW the creation of the query client
+    if (!browserQueryClient) browserQueryClient = makeQueryClient()
+    return browserQueryClient
+  }
+}
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  // NOTE: Avoid useState when initializing the query client if you don't
+  //       have a suspense boundary between this and the code that may
+  //       suspend because React will throw away the client on the initial
+  //       render if it suspends and there is no boundary
+  const queryClient = getQueryClient()
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,0 @@
-// react hooks exports

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,6 +1,4 @@
 @import "./globals.css";
-@import "./tokens/typography.css";
-
 @tailwind utilities;
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
## 🔗 연관 이슈

> #11 

Close #11 

## 🛠 작업 내용

- react-query5 설치
- 전역 query 정의
- errorboundary

## 👀 참고 문서

> 작업을 하며 도움이 되었던 문서 링크를 작성해주세요.

- [next14 app router에서 react-query5 세팅 방법](https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr#server-components-and-nextjs-app-routerreact-query-errorboundary)
- [react-query-errorboundary](https://www.mintmin.dev/blog/2404/20240427)




## 🎸 기타 사항

- 직접 실행하면서 루트경로랑 /test경로 들어가서 어떻게 동작하는지 확인해보고 이해안되면 말씀해주세요!
- 잘모르는 개념이라 이틀간 삽질하고 공부하느라 조금 늦었습니다 😢 
