### PR TITLE
[feat/qr-scanner] qr code 스캔 기능 개발

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@ducanh2912/next-pwa": "^10.2.7",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.40.1",
+    "@yudiel/react-qr-scanner": "^2.0.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "eslint-plugin-simple-import-sort": "^12.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.40.1
         version: 5.40.1(react@18.3.1)
+      '@yudiel/react-qr-scanner':
+        specifier: ^2.0.4
+        version: 2.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -1037,6 +1040,12 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
+  '@types/dom-webcodecs@0.1.11':
+    resolution: {integrity: sha512-yPEZ3z7EohrmOxbk/QTAa0yonMFkNkjnVXqbGb7D4rMr+F1dGQ8ZUFxXkyLLJuiICPejZ0AZE9Rrk9wUCczx4A==}
+
+  '@types/emscripten@1.39.13':
+    resolution: {integrity: sha512-cFq+fO/isvhvmuP/+Sl4K4jtU6E23DoivtbO4r50e3odaxAiVdbfSYRDdJ4gCdxx+3aRjhphS5ZMwIH4hFy/Cw==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -1206,6 +1215,12 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  '@yudiel/react-qr-scanner@2.0.4':
+    resolution: {integrity: sha512-ZVSyT6F2S8mdURUCy2Oz9/khZ3DfzsbU8OO5lXYzLzJLVwfhLX+jo2Gd80FyBMqBxM0fbwNNvAawTajcJ3hb8w==}
+    peerDependencies:
+      react: ^17 || ^18
+      react-dom: ^17 || ^18
+
   acorn-import-assertions@1.9.0:
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
     peerDependencies:
@@ -1349,6 +1364,9 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  barcode-detector@2.2.7:
+    resolution: {integrity: sha512-+6PJNcMtdVehX5i2LQUE9L+mS6C3cG00Vsuc4Ynj3Mls5GNKIAFkE0IFGtw4s6vu8SXeogrzTj4btm44oD+gNw==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -2785,6 +2803,9 @@ packages:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
     engines: {node: '>= 10.13.0'}
 
+  sdp@3.2.0:
+    resolution: {integrity: sha512-d7wDPgDV3DDiqulJjKiV2865wKsJ34YI+NDREbm+FySq6WuKOikwyNQcm+doLAZ1O6ltdO0SeKle2xMpN3Brgw==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -3171,6 +3192,10 @@ packages:
       webpack-cli:
         optional: true
 
+  webrtc-adapter@9.0.1:
+    resolution: {integrity: sha512-1AQO+d4ElfVSXyzNVTOewgGT/tAomwwztX/6e3totvyyzXPvXIIuUUjAmyZGbKBKbZOXauuJooZm3g6IuFuiNQ==}
+    engines: {node: '>=6.0.0', npm: '>=3.10.0'}
+
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
@@ -3297,6 +3322,9 @@ packages:
         optional: true
       react:
         optional: true
+
+  zxing-wasm@1.2.11:
+    resolution: {integrity: sha512-rNSMkIU310sK5cCPSjZA58FEhGZUtNx+f0CmtZ3SZzpdwZE6IzzKFdkbFkl8CFnxiUrx1VMVl/2WULDnwwJbfg==}
 
 snapshots:
 
@@ -4456,6 +4484,10 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
+  '@types/dom-webcodecs@0.1.11': {}
+
+  '@types/emscripten@1.39.13': {}
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 8.56.10
@@ -4683,6 +4715,13 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  '@yudiel/react-qr-scanner@2.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      barcode-detector: 2.2.7
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      webrtc-adapter: 9.0.1
+
   acorn-import-assertions@1.9.0(acorn@8.11.3):
     dependencies:
       acorn: 8.11.3
@@ -4857,6 +4896,11 @@ snapshots:
       - supports-color
 
   balanced-match@1.0.2: {}
+
+  barcode-detector@2.2.7:
+    dependencies:
+      '@types/dom-webcodecs': 0.1.11
+      zxing-wasm: 1.2.11
 
   binary-extensions@2.3.0: {}
 
@@ -6401,6 +6445,8 @@ snapshots:
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
 
+  sdp@3.2.0: {}
+
   semver@6.3.1: {}
 
   semver@7.6.0:
@@ -6838,6 +6884,10 @@ snapshots:
       - esbuild
       - uglify-js
 
+  webrtc-adapter@9.0.1:
+    dependencies:
+      sdp: 3.2.0
+
   whatwg-url@7.1.0:
     dependencies:
       lodash.sortby: 4.7.0
@@ -7047,3 +7097,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
       react: 18.3.1
+
+  zxing-wasm@1.2.11:
+    dependencies:
+      '@types/emscripten': 1.39.13

--- a/src/app/qr/lib/index.ts
+++ b/src/app/qr/lib/index.ts
@@ -1,0 +1,14 @@
+export const FOUR_CUT_BRAND = {
+  PHOTOISM: "https://qr.seobuk.kr",
+  DONTLXXKUP: "https://x.dontlxxkup.kr",
+  HARUFILM: "http://haru6.mx2.co.kr",
+}
+
+// 객체의 value들을 정규표현식 패턴으로 결합
+const urlPatterns = Object.values(FOUR_CUT_BRAND)
+  .map((url) => url.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&") + ".*")
+  .join("|")
+
+// 입력된 문자열이 객체의 value에 포함되어 있는지 확인하는 함수
+export const isUrlIncluded = (input: string) =>
+  new RegExp(`^(${urlPatterns})$`).test(input)

--- a/src/app/qr/page.css
+++ b/src/app/qr/page.css
@@ -1,18 +1,38 @@
 /* App.css */
 .fullscreen-qr-scanner {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
   height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: black; /* 배경을 검정색으로 설정하여 QR 스캐너가 더 잘 보이게 합니다. */
+  background: var(--Gray-900, #181c23);
 }
 
 .fullscreen-qr-scanner video {
   object-fit: cover;
-  width: 100vw;
+}
+
+.fullscreen-qr-scanner__overlay {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   height: 100vh;
+}
+
+.fullscreen-qr-scanner__overlay__inner {
+  width: 345px;
+  height: 345px;
+  border-radius: 24px;
+  border: 4px solid var(--Green-600, #28cb87);
+  box-shadow: 0 0 0 100vmax rgba(0, 0, 0, 0.7);
+}
+
+.test {
+}
+
+.clear {
+  position: relative;
+  z-index: 1;
+}
+
+button {
+  position: relative;
+  z-index: 1;
+  color: white;
 }

--- a/src/app/qr/page.css
+++ b/src/app/qr/page.css
@@ -1,0 +1,18 @@
+/* App.css */
+.fullscreen-qr-scanner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: black; /* 배경을 검정색으로 설정하여 QR 스캐너가 더 잘 보이게 합니다. */
+}
+
+.fullscreen-qr-scanner video {
+  object-fit: cover;
+  width: 100vw;
+  height: 100vh;
+}

--- a/src/app/qr/page.tsx
+++ b/src/app/qr/page.tsx
@@ -6,7 +6,13 @@ import { IDetectedBarcode, Scanner } from "@yudiel/react-qr-scanner"
 import { isUrlIncluded } from "./lib"
 
 const style = {
-  container: { width: "100%", height: "100%" },
+  container: {
+    display: "flex !important",
+    color: "red",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  finderBorder: 100,
 }
 
 const QrPage = () => {
@@ -28,7 +34,20 @@ const QrPage = () => {
         styles={style}
         scanDelay={500}
         allowMultiple={true}
-      />
+        components={{
+          onOff: true,
+          finder: false,
+        }}>
+        <>
+          <p className="text-header-2 font-bold text-white clear">홈</p>
+          <div>
+            <button>버튼 텍스트</button>
+          </div>
+          <div className="fullscreen-qr-scanner__overlay">
+            <div className="fullscreen-qr-scanner__overlay__inner" />
+          </div>
+        </>
+      </Scanner>
     </div>
   )
 }

--- a/src/app/qr/page.tsx
+++ b/src/app/qr/page.tsx
@@ -1,7 +1,13 @@
 "use client"
+import "./page.css" // 스타일 정의를 위한 CSS 파일을 포함합니다.
+
 import { IDetectedBarcode, Scanner } from "@yudiel/react-qr-scanner"
 
 import { isUrlIncluded } from "./lib"
+
+const style = {
+  container: { width: "100%", height: "100%" },
+}
 
 const QrPage = () => {
   const onScan = (result: IDetectedBarcode[]) => {
@@ -16,8 +22,13 @@ const QrPage = () => {
   }
 
   return (
-    <div>
-      <Scanner onScan={onScan} />
+    <div className="fullscreen-qr-scanner">
+      <Scanner
+        onScan={onScan}
+        styles={style}
+        scanDelay={500}
+        allowMultiple={true}
+      />
     </div>
   )
 }

--- a/src/app/qr/page.tsx
+++ b/src/app/qr/page.tsx
@@ -1,0 +1,25 @@
+"use client"
+import { IDetectedBarcode, Scanner } from "@yudiel/react-qr-scanner"
+
+import { isUrlIncluded } from "./lib"
+
+const QrPage = () => {
+  const onScan = (result: IDetectedBarcode[]) => {
+    const { rawValue } = result[0]
+
+    if (!isUrlIncluded(rawValue)) {
+      alert("지원하지 않는 QR코드입니다.")
+      return
+    }
+
+    alert(rawValue)
+  }
+
+  return (
+    <div>
+      <Scanner onScan={onScan} />
+    </div>
+  )
+}
+
+export default QrPage

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,10 @@
 
 @layer base {
   :root {
+    max-width: 393px;
+    margin: 0 auto;
+    background-color: red;
+
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
 


### PR DESCRIPTION
## 🔗 연관 이슈

> 이 PR과 연관된 이슈 번호를 작성해주세요

Close #20 

## 🛠 작업 내용

- qr scanner 라이브러리를 설치해서 qr code 스캔을 합니다.
- 스캔을 통해 추출한 url을 지정한 브랜드(네컷 브랜드 url)와 비교해서 가지고 있는 도메인일 경우 alert와 함께 성공 메시지 노출
- 지원하지 않는 브랜드일 경우 지원하지 않는 브랜드라고 alert 노출

## 🖼 스크린샷

> 구현한 기능의 스크린샷을 첨부해주세요.

|기본이미지|스캔성공시|
| --- | --- |
|![image](https://github.com/YAPP-Github/24th-Web-Team-3-FE/assets/52727782/bac7bfdd-b334-447f-8a93-d8bc5aac6b91)|![image](https://github.com/YAPP-Github/24th-Web-Team-3-FE/assets/52727782/dd4f6c11-1b01-4322-9516-3d2af9bf8455)|

## 👀 참고 문서

> 작업을 하며 도움이 되었던 문서 링크를 작성해주세요.

- [qr-scanner-libray](https://github.com/yudielcurbelo/react-qr-scanner)

## 🎸 기타 사항

- 지원하지 않는 브랜드일 경우 mvp에서 어떻게 할지...? iframe으로 제공할지..? 아니면 alert와 문구로 지원 x할지...? 한 번 더 논의 (시간적인 요소...)
- 하단에 아이콘 컴포넌트가 없습니다. 이를 추가해야하는데 혹시 지은님이 하시던것을 다하고 여유가 되시면 해주실 수 있을지 여쭤봅니다. 안된다면 아직 해당 기능이 없기 때문에 우선순위를 낮추어 나중에 제가 개발하면 될 것 같습니다.!  

