### PR TITLE
[feat/album-refactor] 앨범 생성시 react-query 이용을 통한 에러핸들링

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,7 +17,7 @@ const nextConfig = {
       },
       {
         protocol: "http",
-        hostname: "t1.kakaocdn.net",
+        hostname: "*.kakaocdn.net",
         pathname: "/**",
       },
     ],

--- a/src/app/album/[id]/_component/AlbumPhotos.tsx
+++ b/src/app/album/[id]/_component/AlbumPhotos.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { useDeletePhoto, useGetPhotos } from "@/app/scanner/hooks/usePhoto"
 
@@ -27,11 +27,13 @@ export const AlbumPhotos = ({ albumId }: { albumId: string }) => {
   const handleDelete = async (photoIdx: number) => {
     deletePhoto(photos[photoIdx].photoId)
     photosRefetch()
+  }
 
+  useEffect(() => {
     if (!photos.length) {
       setImageDetailShown(false)
     }
-  }
+  }, [photos])
 
   return (
     <>

--- a/src/app/album/[id]/_component/AlbumPhotos.tsx
+++ b/src/app/album/[id]/_component/AlbumPhotos.tsx
@@ -1,18 +1,19 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useRef, useState } from "react"
 
-import { deletePhoto, getPhotos } from "@/app/api/photo"
+import { useDeletePhoto, useGetPhotos } from "@/app/scanner/hooks/usePhoto"
 
-import { PhotoInfo } from "../../types"
 import { ImageDetail } from "./ImageDetail"
 import { Photo } from "./Photo"
 import { PhotoAddButton } from "./PhotoAddButton"
 
 export const AlbumPhotos = ({ albumId }: { albumId: string }) => {
-  const [photos, setPhotos] = useState<PhotoInfo[]>([])
   const [imageDetailShown, setImageDetailShown] = useState(false)
   const carouselStartIdx = useRef(0)
+  const { deletePhoto } = useDeletePhoto()
+
+  const { photos, photosRefetch } = useGetPhotos(albumId)
 
   const onPhotoClick = (startIdx: number) => {
     carouselStartIdx.current = startIdx
@@ -24,26 +25,13 @@ export const AlbumPhotos = ({ albumId }: { albumId: string }) => {
   }
 
   const handleDelete = async (photoIdx: number) => {
-    await deletePhoto(photos[photoIdx].photoId)
+    deletePhoto(photos[photoIdx].photoId)
+    photosRefetch()
 
-    const nextPhotos = photos.filter((v, i) => i !== photoIdx)
-    setPhotos(nextPhotos)
-
-    if (!nextPhotos.length) {
+    if (!photos.length) {
       setImageDetailShown(false)
     }
   }
-
-  useEffect(() => {
-    const fetchAlbums = async () => {
-      const data = await getPhotos(albumId)
-      if (data.length) {
-        setPhotos(() => data)
-      }
-    }
-
-    fetchAlbums()
-  }, [albumId])
 
   return (
     <>

--- a/src/app/album/[id]/_component/Header.tsx
+++ b/src/app/album/[id]/_component/Header.tsx
@@ -1,20 +1,19 @@
 "use client"
 
 import { useRouter } from "next/navigation"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
-import { getAlbum } from "@/app/api/photo"
-import { deleteAlbum } from "@/app/api/photo"
 import Icon from "@/common/Icon"
 import { ICON_COLOR_STYLE, ICON_NAME } from "@/constants"
 import { albumDetailHeaderVariants as headerVariants } from "@/styles/variants"
 import { cn } from "@/utils"
 
-import { AlbumInfo } from "../../types"
+import { useDeleteAlbum, useGetAlbum } from "../../create/hooks/useAlbum"
 import { Dialog } from "./Dialog"
 
 export const Header = ({ albumId }: { albumId: string }) => {
-  const [album, setAlbum] = useState<AlbumInfo | null>(null)
+  const { albumInfo } = useGetAlbum(albumId)
+  const { deleteAlbum } = useDeleteAlbum()
   const [isModalShown, setIsModalShown] = useState(false)
   const router = useRouter()
 
@@ -26,44 +25,32 @@ export const Header = ({ albumId }: { albumId: string }) => {
   }
 
   const handleDeleteAlbum = async () => {
-    await deleteAlbum(album!.albumId)
+    deleteAlbum({ albumId: albumInfo.albumId })
     router.push("/album")
   }
 
   const dialogProps = {
-    title: `'${album?.name}' 앨범을 삭제할까요?`,
+    title: `'${albumInfo.name}' 앨범을 삭제할까요?`,
     desc: "모든 사진도 함께 삭제되며, 복구할 수 없어요",
     confirmBtnContext: "앨범 삭제",
     onClose: onDialogCloseClick,
     onConfirm: handleDeleteAlbum,
   }
 
-  useEffect(() => {
-    const initAlbum = async (albumId: string) => {
-      const data = await getAlbum(albumId)
-      if (data) {
-        setAlbum(() => data)
-      }
-    }
-    initAlbum(albumId)
-  }, [albumId])
-
-  if (!album) {
+  if (!albumInfo) {
     return <header className={cn(headerVariants())}></header>
   }
 
+  const { type, name } = albumInfo
+
   return (
-    <header className={cn(headerVariants({ type: album.type }))}>
+    <header className={cn(headerVariants({ type }))}>
       <button onClick={() => router.push("/album")}>
         <Icon name="altArrowLeftOutline" size={28} />
       </button>
       <div className="flex gap-1 text-title-2 font-bold text-gray-800">
-        <Icon
-          name={ICON_NAME[album.type]}
-          color={ICON_COLOR_STYLE[album.type]}
-          size={28}
-        />
-        {album.name}
+        <Icon name={ICON_NAME[type]} color={ICON_COLOR_STYLE[type]} size={28} />
+        {name}
       </div>
       <button
         className="text-body-1 font-medium text-red-600"

--- a/src/app/album/[id]/_component/Header.tsx
+++ b/src/app/album/[id]/_component/Header.tsx
@@ -8,17 +8,12 @@ import { ICON_COLOR_STYLE, ICON_NAME } from "@/constants"
 import { albumDetailHeaderVariants as headerVariants } from "@/styles/variants"
 import { cn } from "@/utils"
 
-import {
-  useDeleteAlbum,
-  useGetAlbum,
-  useGetAlbums,
-} from "../../create/hooks/useAlbum"
+import { useDeleteAlbum, useGetAlbum } from "../../create/hooks/useAlbum"
 import { Dialog } from "./Dialog"
 
 export const Header = ({ albumId }: { albumId: string }) => {
   const { albumInfo } = useGetAlbum(albumId)
   const { deleteAlbum } = useDeleteAlbum()
-  const { getAlbumsRefetch } = useGetAlbums()
   const [isModalShown, setIsModalShown] = useState(false)
   const router = useRouter()
 
@@ -29,9 +24,8 @@ export const Header = ({ albumId }: { albumId: string }) => {
     setIsModalShown(false)
   }
 
-  const handleDeleteAlbum = async () => {
+  const handleDeleteAlbum = () => {
     deleteAlbum({ albumId: albumInfo.albumId })
-    getAlbumsRefetch()
 
     router.push("/album")
   }

--- a/src/app/album/[id]/_component/Header.tsx
+++ b/src/app/album/[id]/_component/Header.tsx
@@ -8,12 +8,17 @@ import { ICON_COLOR_STYLE, ICON_NAME } from "@/constants"
 import { albumDetailHeaderVariants as headerVariants } from "@/styles/variants"
 import { cn } from "@/utils"
 
-import { useDeleteAlbum, useGetAlbum } from "../../create/hooks/useAlbum"
+import {
+  useDeleteAlbum,
+  useGetAlbum,
+  useGetAlbums,
+} from "../../create/hooks/useAlbum"
 import { Dialog } from "./Dialog"
 
 export const Header = ({ albumId }: { albumId: string }) => {
   const { albumInfo } = useGetAlbum(albumId)
   const { deleteAlbum } = useDeleteAlbum()
+  const { getAlbumsRefetch } = useGetAlbums()
   const [isModalShown, setIsModalShown] = useState(false)
   const router = useRouter()
 
@@ -26,6 +31,8 @@ export const Header = ({ albumId }: { albumId: string }) => {
 
   const handleDeleteAlbum = async () => {
     deleteAlbum({ albumId: albumInfo.albumId })
+    getAlbumsRefetch()
+
     router.push("/album")
   }
 

--- a/src/app/album/_component/Albums.tsx
+++ b/src/app/album/_component/Albums.tsx
@@ -1,25 +1,10 @@
 "use client"
 
-import { useEffect, useState } from "react"
-
-import { getAlbums } from "@/app/api/photo"
-
-import { AlbumInfo } from "../types"
+import { useGetAlbums } from "../create/hooks/useAlbum"
 import { Album } from "./Album"
 
 export const Albums = () => {
-  const [albums, setAlbums] = useState<AlbumInfo[] | null>(null)
-
-  useEffect(() => {
-    const albumsInit = async () => {
-      const albums = await getAlbums()
-
-      setAlbums(() => albums)
-    }
-    albumsInit()
-  }, [])
-
-  if (!albums) return <></>
+  const { albums } = useGetAlbums()
 
   if (!albums.length)
     return (

--- a/src/app/album/create/_components/AlbumEditSection.tsx
+++ b/src/app/album/create/_components/AlbumEditSection.tsx
@@ -52,11 +52,12 @@ export function AlbumEditSection({
   }
 
   useEffect(() => {
-    if (!albumInfo || !photoId) return
-
+    if (!albumInfo) return
     const { albumId } = albumInfo
 
-    patchPhotoAlbum({ photoId, albumId })
+    if (photoId) {
+      patchPhotoAlbum({ photoId, albumId })
+    }
 
     router.push(`/album/${albumId}`)
   }, [albumInfo, patchPhotoAlbum, photoId, router])

--- a/src/app/album/create/_components/AlbumEditSection.tsx
+++ b/src/app/album/create/_components/AlbumEditSection.tsx
@@ -1,13 +1,15 @@
 "use client"
 
 import { useRouter, useSearchParams } from "next/navigation"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
-import { patchPhotoAlbum, postAlbum } from "@/app/api/photo"
+import { usePatchPhotoAlbum } from "@/app/scanner/hooks/usePhoto"
 import AlbumItem from "@/common/AlbumItem"
 import Button from "@/common/Button"
+import Loading from "@/common/Loading"
 
 import { AlbumType, AlbumValue } from "../../types"
+import { usePostAlbum } from "../hooks/useAlbum"
 import AlbumTypeSelectTab from "./AlbumTypeSelectTab"
 
 interface AlbumCreateSectionProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -26,40 +28,48 @@ const DEFAULT_ALBUM_VALUE: AlbumValue = {
 export function AlbumEditSection({
   albumValue: albumValueInit = DEFAULT_ALBUM_VALUE,
 }: AlbumCreateSectionProps) {
+  const { patchPhotoAlbum } = usePatchPhotoAlbum()
+  const { albumInfo, postAlbum, isPending } = usePostAlbum()
   const [value, setValue] = useState(albumValueInit)
-  const { type } = value
   const router = useRouter()
   const searchParams = useSearchParams()
   const photoId = searchParams.get("photoId")
 
   const handleType = (type: AlbumType) => {
-    const nextValue = {
-      ...value,
+    setValue((prev) => ({
+      ...prev,
       type,
-    }
-    setValue(() => nextValue)
+    }))
   }
 
   const handleValue = (v: AlbumValue) => {
-    setValue(() => v)
+    setValue(v)
   }
 
   const handleSubmit = async () => {
     const { name, type } = value
-    const { albumId } = await postAlbum(name, type)
-    if (photoId) {
-      await patchPhotoAlbum(photoId, albumId)
-    }
-    router.push(`/album/${albumId}`)
+    postAlbum({ name, type })
   }
+
+  useEffect(() => {
+    if (!albumInfo || !photoId) return
+
+    const { albumId } = albumInfo
+
+    patchPhotoAlbum({ photoId, albumId })
+
+    router.push(`/album/${albumId}`)
+  }, [albumInfo, patchPhotoAlbum, photoId, router])
 
   return (
     <>
+      {isPending && <Loading />}
+
       <div className="flex w-full justify-center pt-6">
         <AlbumItem value={value} handleValue={handleValue} />
       </div>
       <div className="fixed bottom-0 flex w-full max-w-[430px] flex-col items-center">
-        <AlbumTypeSelectTab type={type} handleType={handleType} />
+        <AlbumTypeSelectTab type={value.type} handleType={handleType} />
         <Button
           className="mb-11 mt-3 w-[calc(100%-3rem)]"
           onClick={handleSubmit}

--- a/src/app/album/create/hooks/useAlbum.ts
+++ b/src/app/album/create/hooks/useAlbum.ts
@@ -44,10 +44,12 @@ export const useGetAlbum = (albumId: string) => {
 
 export const useDeleteAlbum = () => {
   const { showAlert } = useAlert()
+  const { getAlbumsRefetch } = useGetAlbums()
 
   const { mutate } = useMutation({
     mutationFn: ({ albumId }: { albumId: string }) => deleteAlbum(albumId),
     mutationKey: ["deleteAlbum"],
+    onSuccess: () => getAlbumsRefetch(),
     onError: (error) => {
       showAlert("앗! 앨범을 삭제하지 못했어요", error.message)
     },

--- a/src/app/album/create/hooks/useAlbum.ts
+++ b/src/app/album/create/hooks/useAlbum.ts
@@ -1,0 +1,22 @@
+import { useMutation } from "@tanstack/react-query"
+
+import { postAlbum } from "@/app/api/photo"
+import { useAlert } from "@/store/AlertContext"
+
+import { AlbumType } from "../../types"
+
+export const usePostAlbum = () => {
+  const { showAlert } = useAlert()
+
+  const { data, mutate, isPending } = useMutation({
+    mutationFn: ({ name, type }: { name: string; type: AlbumType }) =>
+      postAlbum(name, type),
+    mutationKey: ["postAlbum"],
+    onError: (error) => {
+      showAlert("앗! 앨범을 추가하지 못했어요", error.message)
+    },
+    throwOnError: true,
+  })
+
+  return { albumInfo: data, postAlbum: mutate, isPending }
+}

--- a/src/app/album/create/hooks/useAlbum.ts
+++ b/src/app/album/create/hooks/useAlbum.ts
@@ -1,6 +1,6 @@
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query"
 
-import { postAlbum } from "@/app/api/photo"
+import { deleteAlbum, getAlbum, getAlbums, postAlbum } from "@/app/api/photo"
 import { useAlert } from "@/store/AlertContext"
 
 import { AlbumType } from "../../types"
@@ -19,4 +19,39 @@ export const usePostAlbum = () => {
   })
 
   return { albumInfo: data, postAlbum: mutate, isPending }
+}
+
+export const useGetAlbums = () => {
+  const { data } = useSuspenseQuery({
+    queryKey: ["getAlbums"],
+    queryFn: getAlbums,
+  })
+
+  return {
+    albums: data,
+  }
+}
+
+export const useGetAlbum = (albumId: string) => {
+  const { data } = useSuspenseQuery({
+    queryKey: ["getAlbum", albumId],
+    queryFn: () => getAlbum(albumId),
+  })
+
+  return { albumInfo: data }
+}
+
+export const useDeleteAlbum = () => {
+  const { showAlert } = useAlert()
+
+  const { mutate } = useMutation({
+    mutationFn: ({ albumId }: { albumId: string }) => deleteAlbum(albumId),
+    mutationKey: ["deleteAlbum"],
+    onError: (error) => {
+      showAlert("앗! 앨범을 삭제하지 못했어요", error.message)
+    },
+    throwOnError: true,
+  })
+
+  return { deleteAlbum: mutate }
 }

--- a/src/app/album/create/hooks/useAlbum.ts
+++ b/src/app/album/create/hooks/useAlbum.ts
@@ -22,13 +22,14 @@ export const usePostAlbum = () => {
 }
 
 export const useGetAlbums = () => {
-  const { data } = useSuspenseQuery({
+  const { data, refetch } = useSuspenseQuery({
     queryKey: ["getAlbums"],
     queryFn: getAlbums,
   })
 
   return {
     albums: data,
+    getAlbumsRefetch: refetch,
   }
 }
 

--- a/src/app/api/photo.ts
+++ b/src/app/api/photo.ts
@@ -78,7 +78,7 @@ export const deleteAlbum = async (albumId: string): Promise<AlbumInfo> => {
 }
 
 export const deletePhoto = async (photoId: string): Promise<null> => {
-  await myFetch(`/photo/v1/albums/${photoId}`, {
+  await myFetch(`/photo/v1/photos/${photoId}`, {
     method: "DELETE",
   })
   return null

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,5 +1,7 @@
-const Loading = () => {
-  return <div>전역 loding...</div>
+import Loading from "@/common/Loading"
+
+const LoadingPage = () => {
+  return <Loading />
 }
 
-export default Loading
+export default LoadingPage

--- a/src/app/profile/_components/Header.tsx
+++ b/src/app/profile/_components/Header.tsx
@@ -18,9 +18,8 @@ const Header = () => {
           alt="프로필 이미지"
           width={108}
           height={108}
-          className="rounded-full"
+          className="h-[108px] w-[108px] rounded-full object-cover"
         />
-
         <p className="tp-header2-semibold text-gray-700">{userInfo.name}</p>
       </div>
     </>

--- a/src/app/profile/_components/Header.tsx
+++ b/src/app/profile/_components/Header.tsx
@@ -1,22 +1,11 @@
 "use client"
 
 import Image from "next/image"
-import { useEffect, useState } from "react"
 
-import { getMyProfile, GetMyProfileResponse } from "@/app/api/login"
+import { useGetMyProfile } from "../hooks/useProfile"
 
 const Header = () => {
-  const [userInfo, setUserInfo] = useState<GetMyProfileResponse>()
-  useEffect(() => {
-    const fetchGetMyProfile = async () => {
-      const data = await getMyProfile()
-      setUserInfo(data)
-    }
-
-    fetchGetMyProfile()
-  }, [])
-
-  if (!userInfo) return null
+  const { userInfo } = useGetMyProfile()
 
   return (
     <>

--- a/src/app/profile/hooks/useProfile.ts
+++ b/src/app/profile/hooks/useProfile.ts
@@ -1,0 +1,14 @@
+import { useSuspenseQuery } from "@tanstack/react-query"
+
+import { getMyProfile } from "@/app/api/login"
+
+export const useGetMyProfile = () => {
+  const { data } = useSuspenseQuery({
+    queryKey: ["getMyProfile"],
+    queryFn: getMyProfile,
+  })
+
+  return {
+    userInfo: data,
+  }
+}

--- a/src/app/scanner/_component/PhotoModal.tsx
+++ b/src/app/scanner/_component/PhotoModal.tsx
@@ -44,7 +44,7 @@ export const PhotoModal = ({ scanInfo, onClose }: PhotoModalProps) => {
           src={photoUrl}
           width={WIDTH}
           height={height}
-          style={{ width: "auto", height: "auto" }}
+          style={{ height: "350px", width: "auto" }}
           alt="scanner_image"
           onLoad={(e) => {
             handleLoadingComplete(

--- a/src/app/scanner/hooks/usePhoto.ts
+++ b/src/app/scanner/hooks/usePhoto.ts
@@ -1,6 +1,11 @@
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query"
 
-import { patchPhotoAlbum, postQrCode } from "@/app/api/photo"
+import {
+  deletePhoto,
+  getPhotos,
+  patchPhotoAlbum,
+  postQrCode,
+} from "@/app/api/photo"
 import { useAlert } from "@/store/AlertContext"
 
 export const usePostQrCode = () => {
@@ -12,7 +17,6 @@ export const usePostQrCode = () => {
     onError: (error) => {
       showAlert("앗! 사진을 불러오지 못했어요", error.message)
     },
-
     // throwOnError: true,
   })
 
@@ -36,4 +40,31 @@ export const usePatchPhotoAlbum = () => {
   })
 
   return { patchPhotoAlbum: mutate }
+}
+
+export const useDeletePhoto = () => {
+  const { showAlert } = useAlert()
+
+  const { mutate } = useMutation({
+    mutationFn: (photoId: string) => deletePhoto(photoId),
+    mutationKey: ["deletePhoto"],
+    onError: (error) => {
+      showAlert("앗! 사진을 삭제하지 못했어요", error.message)
+    },
+    throwOnError: true,
+  })
+
+  return { deletePhoto: mutate }
+}
+
+export const useGetPhotos = (albumId: string) => {
+  const { data, refetch } = useSuspenseQuery({
+    queryKey: ["getPhotos", albumId],
+    queryFn: () => getPhotos(albumId),
+  })
+
+  return {
+    photos: data,
+    photosRefetch: refetch,
+  }
 }

--- a/src/app/scanner/hooks/usePhoto.ts
+++ b/src/app/scanner/hooks/usePhoto.ts
@@ -1,6 +1,6 @@
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query"
+import { useMutation } from "@tanstack/react-query"
 
-import { getAlbums, patchPhotoAlbum, postQrCode } from "@/app/api/photo"
+import { patchPhotoAlbum, postQrCode } from "@/app/api/photo"
 import { useAlert } from "@/store/AlertContext"
 
 export const usePostQrCode = () => {
@@ -20,17 +20,6 @@ export const usePostQrCode = () => {
     scanInfo: data,
     postQrCodeQuery: mutate,
     isPending,
-  }
-}
-
-export const useGetAlbums = () => {
-  const { data } = useSuspenseQuery({
-    queryKey: ["getAlbums"],
-    queryFn: getAlbums,
-  })
-
-  return {
-    albums: data,
   }
 }
 

--- a/src/app/scanner/hooks/usePhoto.ts
+++ b/src/app/scanner/hooks/usePhoto.ts
@@ -30,7 +30,7 @@ export const useGetAlbums = () => {
   })
 
   return {
-    albumLength: data.length,
+    albums: data,
   }
 }
 

--- a/src/app/scanner/hooks/usePhoto.ts
+++ b/src/app/scanner/hooks/usePhoto.ts
@@ -35,15 +35,15 @@ export const useGetAlbums = () => {
 }
 
 export const usePatchPhotoAlbum = () => {
+  const { showAlert } = useAlert()
+
   const { mutate } = useMutation({
-    mutationFn: ({
-      photoId,
-      defaultAlbumId,
-    }: {
-      photoId: string
-      defaultAlbumId: string
-    }) => patchPhotoAlbum(photoId, defaultAlbumId),
+    mutationFn: ({ photoId, albumId }: { photoId: string; albumId: string }) =>
+      patchPhotoAlbum(photoId, albumId),
     mutationKey: ["patchPhotoAlbum"],
+    onError: (error) => {
+      showAlert("앗! 앨범에 사진을 추가하지 못했어요", error.message)
+    },
   })
 
   return { patchPhotoAlbum: mutate }

--- a/src/app/scanner/page.tsx
+++ b/src/app/scanner/page.tsx
@@ -65,7 +65,7 @@ const ScannerPage = () => {
 
     // 기본 앨범이 있다면 기본 앨범에 사진 추가
     if (defaultAlbumId) {
-      patchPhotoAlbum({ photoId, defaultAlbumId })
+      patchPhotoAlbum({ photoId, albumId: defaultAlbumId })
       router.push(`/album/${defaultAlbumId}`)
       return
     }

--- a/src/app/scanner/page.tsx
+++ b/src/app/scanner/page.tsx
@@ -34,7 +34,7 @@ const ScannerPage = () => {
   const searchParams = useSearchParams()
   const defaultAlbumId = searchParams.get("defaultAlbumId")
   const { scanInfo, postQrCodeQuery, isPending } = usePostQrCode()
-  const { albumLength } = useGetAlbums()
+  const { albums } = useGetAlbums()
   const { patchPhotoAlbum } = usePatchPhotoAlbum()
   const [isPhotoModalShown, setIsPhotoModalShown] = useState(false)
 
@@ -58,7 +58,7 @@ const ScannerPage = () => {
     const { photoId } = scanInfo
 
     // 만든 앨범이 하나도 없다면 앨범 생성 페이지로 바로 이동
-    if (!albumLength) {
+    if (!albums.length) {
       router.push(`/album/create?photoId=${photoId}`)
       return
     }
@@ -71,7 +71,7 @@ const ScannerPage = () => {
     }
 
     setIsPhotoModalShown(true)
-  }, [albumLength, defaultAlbumId, patchPhotoAlbum, router, scanInfo])
+  }, [albums.length, defaultAlbumId, patchPhotoAlbum, router, scanInfo])
 
   const closePhotoModal = () => {
     setIsPhotoModalShown(false)

--- a/src/app/scanner/page.tsx
+++ b/src/app/scanner/page.tsx
@@ -8,12 +8,9 @@ import { BottomBar } from "@/common/BottomBar"
 import Loading from "@/common/Loading"
 import { isUrlIncluded } from "@/libs"
 
+import { useGetAlbums } from "../album/create/hooks/useAlbum"
 import { PhotoModal } from "./_component/PhotoModal"
-import {
-  useGetAlbums,
-  usePatchPhotoAlbum,
-  usePostQrCode,
-} from "./hooks/usePhoto"
+import { usePatchPhotoAlbum, usePostQrCode } from "./hooks/usePhoto"
 
 const style = {
   container: {

--- a/src/app/scanner/select-album/page.tsx
+++ b/src/app/scanner/select-album/page.tsx
@@ -27,16 +27,19 @@ const ScannerSelectAlbumPage = () => {
 
     if (selectedAlbum && albumData[idx].albumId === selectedAlbum.albumId) {
       setSelectedAlbum(null)
-      return
+      const nextAlbums = albumData?.map((album) => {
+        return { ...album, isSelected: false }
+      })
+      setAlbumData(nextAlbums)
+    } else {
+      setSelectedAlbum(albumData[idx])
+      const nextAlbums = albumData?.map((album, i) =>
+        i !== idx
+          ? { ...album, isSelected: false }
+          : { ...album, isSelected: true }
+      )
+      setAlbumData(nextAlbums)
     }
-
-    const nextAlbums = albumData?.map((album, i) =>
-      i !== idx
-        ? { ...album, isSelected: false }
-        : { ...album, isSelected: true }
-    )
-    setSelectedAlbum(albumData[idx])
-    setAlbumData(nextAlbums)
   }
 
   const onSubmit = async () => {

--- a/src/app/scanner/select-album/page.tsx
+++ b/src/app/scanner/select-album/page.tsx
@@ -4,11 +4,12 @@ import { useSearchParams } from "next/navigation"
 import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 
+import { useGetAlbums } from "@/app/album/create/hooks/useAlbum"
 import { AlbumValue } from "@/app/album/types"
 import AlbumItem from "@/common/AlbumItem"
 import Button from "@/common/Button"
 
-import { useGetAlbums, usePatchPhotoAlbum } from "../hooks/usePhoto"
+import { usePatchPhotoAlbum } from "../hooks/usePhoto"
 import { Header } from "./_component/Header"
 
 const ScannerSelectAlbumPage = () => {

--- a/src/app/scanner/select-album/page.tsx
+++ b/src/app/scanner/select-album/page.tsx
@@ -73,13 +73,16 @@ const ScannerSelectAlbumPage = () => {
       <Header />
       <section className="flex w-full flex-wrap justify-between gap-y-4 p-6">
         {albumData.map((album, i) => (
-          <AlbumItem
+          <div
             key={i}
-            value={album}
-            handleValue={() => {}}
             className="aspect-[164/150] w-[calc((100%-1rem)/2)]"
-            onClick={() => handleSelectAlbum(i)}
-          />
+            onClick={() => handleSelectAlbum(i)}>
+            <AlbumItem
+              value={album}
+              handleValue={() => {}}
+              className="h-full w-full"
+            />
+          </div>
         ))}
       </section>
       <div className="absolute bottom-0 w-full p-6 pb-11 pt-3">

--- a/src/app/scanner/select-album/page.tsx
+++ b/src/app/scanner/select-album/page.tsx
@@ -5,11 +5,10 @@ import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 
 import { AlbumValue } from "@/app/album/types"
-import { patchPhotoAlbum } from "@/app/api/photo"
 import AlbumItem from "@/common/AlbumItem"
 import Button from "@/common/Button"
 
-import { useGetAlbums } from "../hooks/usePhoto"
+import { useGetAlbums, usePatchPhotoAlbum } from "../hooks/usePhoto"
 import { Header } from "./_component/Header"
 
 const ScannerSelectAlbumPage = () => {
@@ -17,6 +16,8 @@ const ScannerSelectAlbumPage = () => {
   const [albumData, setAlbumData] = useState<AlbumValue[] | null>()
   const [selectedAlbum, setSelectedAlbum] = useState<AlbumValue | null>(null)
   const searchParams = useSearchParams()
+  const { patchPhotoAlbum } = usePatchPhotoAlbum()
+
   const photoId = searchParams.get("photoId")
   const router = useRouter()
 
@@ -38,9 +39,10 @@ const ScannerSelectAlbumPage = () => {
   }
 
   const onSubmit = async () => {
-    if (!selectedAlbum || !photoId) return
+    if (!selectedAlbum?.albumId || !photoId) return
+    const { albumId } = selectedAlbum
 
-    const { albumId } = await patchPhotoAlbum(photoId, selectedAlbum.albumId!)
+    patchPhotoAlbum({ photoId, albumId })
     router.push(`/album/${albumId}`)
   }
 

--- a/src/app/scanner/select-album/page.tsx
+++ b/src/app/scanner/select-album/page.tsx
@@ -5,34 +5,36 @@ import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 
 import { AlbumValue } from "@/app/album/types"
-import { getAlbums, patchPhotoAlbum } from "@/app/api/photo"
+import { patchPhotoAlbum } from "@/app/api/photo"
 import AlbumItem from "@/common/AlbumItem"
 import Button from "@/common/Button"
 
+import { useGetAlbums } from "../hooks/usePhoto"
 import { Header } from "./_component/Header"
 
 const ScannerSelectAlbumPage = () => {
-  const [albums, setAlbums] = useState<AlbumValue[] | null>(null)
+  const { albums } = useGetAlbums()
+  const [albumData, setAlbumData] = useState<AlbumValue[] | null>()
   const [selectedAlbum, setSelectedAlbum] = useState<AlbumValue | null>(null)
   const searchParams = useSearchParams()
   const photoId = searchParams.get("photoId")
   const router = useRouter()
 
   const handleSelectAlbum = (idx: number) => {
-    if (!albums) return
+    if (!albumData) return
 
-    if (selectedAlbum && albums[idx].albumId === selectedAlbum.albumId) {
-      setSelectedAlbum(() => null)
+    if (selectedAlbum && albumData[idx].albumId === selectedAlbum.albumId) {
+      setSelectedAlbum(null)
       return
     }
 
-    const nextAlbums = albums?.map((album, i) =>
+    const nextAlbums = albumData?.map((album, i) =>
       i !== idx
         ? { ...album, isSelected: false }
         : { ...album, isSelected: true }
     )
-    setSelectedAlbum(() => albums[idx])
-    setAlbums(() => nextAlbums)
+    setSelectedAlbum(albumData[idx])
+    setAlbumData(nextAlbums)
   }
 
   const onSubmit = async () => {
@@ -43,30 +45,28 @@ const ScannerSelectAlbumPage = () => {
   }
 
   useEffect(() => {
-    const initAlbums = async () => {
-      const data = await getAlbums()
-      const albums = data.map((v) => {
-        return {
-          ...v,
-          photoCount: Number(v.photoCount),
-          isNew: false,
-          isSelected: false,
-          isEditable: false,
-        }
-      }) as AlbumValue[]
-      setAlbums(() => albums)
-    }
-    initAlbums()
-  }, [])
+    if (!albums) return
 
-  if (!albums) {
+    const albumArray = albums.map((v) => {
+      return {
+        ...v,
+        photoCount: Number(v.photoCount),
+        isNew: false,
+        isSelected: false,
+        isEditable: false,
+      }
+    }) as AlbumValue[]
+    setAlbumData(albumArray)
+  }, [albums])
+
+  if (!albumData) {
     return <></>
   }
   return (
     <main className="relative h-dvh w-full">
       <Header />
       <section className="flex w-full flex-wrap justify-between gap-y-4 p-6">
-        {albums.map((album, i) => (
+        {albumData.map((album, i) => (
           <AlbumItem
             key={i}
             value={album}

--- a/src/common/QueryProviders.tsx
+++ b/src/common/QueryProviders.tsx
@@ -14,7 +14,9 @@ function makeQueryClient() {
       queries: {
         // With SSR, we usually want to set some default staleTime
         // above 0 to avoid refetching immediately on the client
-        staleTime: 60 * 1000, // 1 minute
+        // staleTime: 60 * 1000, // 1 minute
+        staleTime: 0,
+        gcTime: 0,
         throwOnError: true,
         retry: 1,
       },

--- a/src/common/QueryProviders.tsx
+++ b/src/common/QueryProviders.tsx
@@ -16,7 +16,7 @@ function makeQueryClient() {
         // above 0 to avoid refetching immediately on the client
         staleTime: 60 * 1000,
         throwOnError: true,
-        retry: 0,
+        retry: 1,
       },
     },
   })

--- a/src/common/QueryProviders.tsx
+++ b/src/common/QueryProviders.tsx
@@ -14,7 +14,7 @@ function makeQueryClient() {
       queries: {
         // With SSR, we usually want to set some default staleTime
         // above 0 to avoid refetching immediately on the client
-        staleTime: 60 * 1000,
+        staleTime: 60 * 1000, // 1 minute
         throwOnError: true,
         retry: 1,
       },

--- a/src/styles/variants.ts
+++ b/src/styles/variants.ts
@@ -153,7 +153,7 @@ export const badgeVariants = cva(
 )
 
 export const bottomBarVariants = cva(
-  "fixed max-w-[430px] bottom-0 left-0 z-[1] flex w-full justify-evenly rounded-t-2xl pb-8 pt-5 tp-caption1-regular",
+  "fixed max-w-[430px] bottom-0 left-0 z-[1] flex w-full justify-evenly rounded-t-2xl pb-8 pt-5 tp-caption1-regular left-1/2 transform -translate-x-1/2",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## 🔗 연관 이슈

Close #49 

## 🛠 작업 내용

- 기존 api 호출에 대한 로직을 react-query를 이용하게 했습니다. 이로인해 에러 핸들링 및 로딩처리가 가능합니다.
- 앨범생성과 관련된 로직을 리팩토링을 간략하게 진행했습니다.

## 🖼 스크린샷

UI상 달라진 점은 크게 없습니다.