### PR TITLE
fix: scanner 페이지에서의 infinite loading 문제 해결

### DIFF
--- a/src/app/scanner/page.tsx
+++ b/src/app/scanner/page.tsx
@@ -90,7 +90,7 @@ const ScannerPage = () => {
     setIsPhotoModalShown(false)
   }
 
-  if (!deviceId) return <Loading />
+  if (deviceId === undefined) return <Loading />
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">


### PR DESCRIPTION
## 🛠 작업 내용

### 특정 환경의 Scanner 페이지에서 로딩이 무한히 일어나던 문제

#### 환경
- Safari (로컬, 배포 모두)
- Chrome (배포 일부)

#### 문제

Scanner 페이지 접속시 로딩바가 무한히 지속됨.

#### 원인

Safari 등 일부 브라우저에서는 mediaDevices의 deviceId가 `''`(빈 문자열)로 내려오는 것이 문제였습니다.

기존 Scanner 페이지에서는 mediaDevices의 deviceId가 falsy한 값이면 `<Loading/>`을,
truely한 값이면 `<Scanner/>` 컴포넌트를 보여줬습니다.

```js
// 📂 scanner/page.tsx

if(!deviceId) return <Loading />
...
return <Scanner />
```

<br/>

하지만 일부 브라우저(Safari 등)에서는 mediaDevices의 deviceId가  `''`(빈 문자열)로 내려오는 것을 확인했습니다.
(아래 사진 참조)
<img src='https://github.com/user-attachments/assets/b31bff8a-c5f1-42c1-bd3b-faa17a736409' width=200 />

빈 문자열이 Javascript에서는 falsy한 값으로 해석되었기 때문에 위의 분기문을 통과하지 못했고,
이로 인해 계속해서 Loading UI만 보였던 것이었습니다.

#### 해결 방법

분기문의 조건을 `!deviceId`에서 `deviceId === undefined` 로 변경해주었습니다.

<br/>

## 🖼 스크린샷

https://github.com/user-attachments/assets/39d80eab-b46d-4eb0-98d2-8e6f5aad4c01

<br/>

## 🎸 기타 사항

### Chrome에서는...?

정확한 원인을 모르겠어요.
따라서 해당 로직을 일단 dev에 올려보고, 계속해서 문제가 발생하면 딥다이브 할 계획이에요.

덧붙여 **앞으로는 테스트를 꼭 safari에서도 하는 작업이 필요할 것 같아요!🔥🔥**

<br/>