### PR TITLE
[Fix] QA에서 발견된 일부 버그 수정

### DIFF
--- a/src/app/album/create/_components/AlbumEditSection.tsx
+++ b/src/app/album/create/_components/AlbumEditSection.tsx
@@ -6,6 +6,7 @@ import { useState } from "react"
 import { patchPhotoAlbum, postAlbum } from "@/app/api/photo"
 import AlbumItem from "@/common/AlbumItem"
 import Button from "@/common/Button"
+import { getQueryClient } from "@/common/QueryProviders"
 
 import { AlbumType, AlbumValue } from "../../types"
 import AlbumTypeSelectTab from "./AlbumTypeSelectTab"
@@ -31,6 +32,7 @@ export function AlbumEditSection({
   const router = useRouter()
   const searchParams = useSearchParams()
   const photoId = searchParams.get("photoId")
+  const queryClient = getQueryClient()
 
   const handleType = (type: AlbumType) => {
     const nextValue = {
@@ -47,6 +49,8 @@ export function AlbumEditSection({
   const handleSubmit = async () => {
     const { name, type } = value
     const { albumId } = await postAlbum(name, type)
+    queryClient.invalidateQueries({ queryKey: ["getAlbums"] })
+
     if (photoId) {
       await patchPhotoAlbum(photoId, albumId)
     }

--- a/src/app/album/create/_components/AlbumEditSection.tsx
+++ b/src/app/album/create/_components/AlbumEditSection.tsx
@@ -3,12 +3,12 @@
 import { useRouter, useSearchParams } from "next/navigation"
 import { useState } from "react"
 
-import { patchPhotoAlbum, postAlbum } from "@/app/api/photo"
 import AlbumItem from "@/common/AlbumItem"
 import Button from "@/common/Button"
-import { getQueryClient } from "@/common/QueryProviders"
 
+import { usePatchPhotoAlbum } from "../../../scanner/hooks/usePhoto"
 import { AlbumType, AlbumValue } from "../../types"
+import { usePostAlbum } from "../hooks/useAlbum"
 import AlbumTypeSelectTab from "./AlbumTypeSelectTab"
 
 interface AlbumCreateSectionProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -32,7 +32,8 @@ export function AlbumEditSection({
   const router = useRouter()
   const searchParams = useSearchParams()
   const photoId = searchParams.get("photoId")
-  const queryClient = getQueryClient()
+  const { albumInfo, postAlbum } = usePostAlbum()
+  const { patchPhotoAlbum } = usePatchPhotoAlbum()
 
   const handleType = (type: AlbumType) => {
     const nextValue = {
@@ -48,13 +49,13 @@ export function AlbumEditSection({
 
   const handleSubmit = async () => {
     const { name, type } = value
-    const { albumId } = await postAlbum(name, type)
-    queryClient.invalidateQueries({ queryKey: ["getAlbums"] })
+    postAlbum({ name, type })
 
     if (photoId) {
-      await patchPhotoAlbum(photoId, albumId)
+      patchPhotoAlbum({ photoId, defaultAlbumId: albumInfo!.albumId })
     }
-    router.push(`/album/${albumId}`)
+
+    router.push(`/album/${albumInfo!.albumId}`)
   }
 
   return (

--- a/src/app/album/create/hooks/useAlbum.ts
+++ b/src/app/album/create/hooks/useAlbum.ts
@@ -1,0 +1,30 @@
+import { useMutation } from "@tanstack/react-query"
+
+import { postAlbum } from "@/app/api/photo"
+import { getQueryClient } from "@/common/QueryProviders"
+import { useAlert } from "@/store/AlertContext"
+
+import type { AlbumType } from "../../types"
+
+export const usePostAlbum = () => {
+  const { showAlert } = useAlert()
+
+  const { data, mutate, isPending } = useMutation({
+    mutationFn: ({ name, type }: { name: string; type: AlbumType }) =>
+      postAlbum(name, type),
+    mutationKey: ["postAlbum"],
+    onError: (error) => {
+      showAlert("앗! 앨범을 만들지 못했어요", error.message)
+    },
+    onSuccess: () => {
+      const queryClient = getQueryClient()
+      queryClient.invalidateQueries({ queryKey: ["getAlbums"] })
+    },
+    throwOnError: true,
+  })
+  return {
+    albumInfo: data,
+    postAlbum: mutate,
+    isPending,
+  }
+}

--- a/src/common/QueryProviders.tsx
+++ b/src/common/QueryProviders.tsx
@@ -24,7 +24,7 @@ function makeQueryClient() {
 
 let browserQueryClient: QueryClient | undefined = undefined
 
-function getQueryClient() {
+export function getQueryClient() {
   if (isServer) {
     // Server: always make a new query client
     return makeQueryClient()

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -35,10 +35,10 @@ export const LIST_ITEM_INFO: ListItemProps[] = [
       },
       {
         label: "탈퇴하기",
-        action: async () => {
-          await setTimeout(() => {
-            alert("탈퇴 성공")
-          }, 100)
+        action: () => {
+          alert(
+            "아직 지원하는 기능이 아니에요. 다음 업데이트를 기다려주세요 😉"
+          )
         },
       },
     ],
@@ -48,7 +48,12 @@ export const LIST_ITEM_INFO: ListItemProps[] = [
     items: [
       {
         label: "개발팀 소개",
-        link: "/",
+        action: () => {
+          alert(
+            "아직 지원하는 기능이 아니에요. 다음 업데이트를 기다려주세요 😉"
+          )
+        },
+        // link: "/",
       },
       {
         label: "1:1 문의",
@@ -56,7 +61,12 @@ export const LIST_ITEM_INFO: ListItemProps[] = [
       },
       {
         label: "서비스 이용약관",
-        link: "/",
+        action: () => {
+          alert(
+            "아직 지원하는 기능이 아니에요. 다음 업데이트를 기다려주세요 😉"
+          )
+        },
+        // link: "/",
       },
     ],
   },


### PR DESCRIPTION
## 🛠 작업 내용

### fix: 마이페이지 버그 수정
- 개발팀 소개, 서비스 이용약관 클릭시 로그인 페이지로 이동하던 버그 수정
- 탈퇴하기 버튼 클릭시 뜨는 알람 문구를 성공하기 대신 지원하지 않는 기능이라는 문구로 수정

### fix: 첫 앨범을 생성 후 다시 QR을 스캔시, 바로 앨범 생성 페이지로 넘어가는 버그 해결
- react-query의 일부 캐시값이 갱신되지 않아서 발생했던 문제
- cache 무효화를 통해 해결 (`queryClient.invalidateQueries()`)

<br/>

## 👀 참고 문서

- [Query Invalidation](https://tanstack.com/query/v5/docs/framework/react/guides/query-invalidation)

<br/>

## 🎸 기타 사항

### Button Action 상태 정의

는 디자인이 아직 정의되지 않았으므로 디자인 정의 후 반영 예정입니다.