### PR TITLE
[Fix] 앨범 생성이 2번씩 되던 버그 해결

### DIFF
--- a/src/app/album/create/_components/AlbumEditSection.tsx
+++ b/src/app/album/create/_components/AlbumEditSection.tsx
@@ -1,12 +1,11 @@
 "use client"
 
-import { useRouter, useSearchParams } from "next/navigation"
+import { useSearchParams } from "next/navigation"
 import { useState } from "react"
 
 import AlbumItem from "@/common/AlbumItem"
 import Button from "@/common/Button"
 
-import { usePatchPhotoAlbum } from "../../../scanner/hooks/usePhoto"
 import { AlbumType, AlbumValue } from "../../types"
 import { usePostAlbum } from "../hooks/useAlbum"
 import AlbumTypeSelectTab from "./AlbumTypeSelectTab"
@@ -29,11 +28,9 @@ export function AlbumEditSection({
 }: AlbumCreateSectionProps) {
   const [value, setValue] = useState(albumValueInit)
   const { type } = value
-  const router = useRouter()
   const searchParams = useSearchParams()
   const photoId = searchParams.get("photoId")
-  const { albumInfo, postAlbum } = usePostAlbum()
-  const { patchPhotoAlbum } = usePatchPhotoAlbum()
+  const { postAlbum } = usePostAlbum()
 
   const handleType = (type: AlbumType) => {
     const nextValue = {
@@ -49,13 +46,7 @@ export function AlbumEditSection({
 
   const handleSubmit = async () => {
     const { name, type } = value
-    postAlbum({ name, type })
-
-    if (photoId) {
-      patchPhotoAlbum({ photoId, defaultAlbumId: albumInfo!.albumId })
-    }
-
-    router.push(`/album/${albumInfo!.albumId}`)
+    postAlbum({ name, type, photoId })
   }
 
   return (

--- a/src/app/album/create/hooks/useAlbum.ts
+++ b/src/app/album/create/hooks/useAlbum.ts
@@ -1,24 +1,41 @@
 import { useMutation } from "@tanstack/react-query"
+import { useRouter } from "next/navigation"
 
 import { postAlbum } from "@/app/api/photo"
 import { getQueryClient } from "@/common/QueryProviders"
 import { useAlert } from "@/store/AlertContext"
 
+import { usePatchPhotoAlbum } from "../../../scanner/hooks/usePhoto"
 import type { AlbumType } from "../../types"
 
 export const usePostAlbum = () => {
   const { showAlert } = useAlert()
+  const router = useRouter()
+  const { patchPhotoAlbum } = usePatchPhotoAlbum()
 
   const { data, mutate, isPending } = useMutation({
-    mutationFn: ({ name, type }: { name: string; type: AlbumType }) =>
-      postAlbum(name, type),
+    mutationFn: ({
+      name,
+      type,
+    }: {
+      name: string
+      type: AlbumType
+      photoId?: string | null
+    }) => postAlbum(name, type),
     mutationKey: ["postAlbum"],
     onError: (error) => {
       showAlert("앗! 앨범을 만들지 못했어요", error.message)
     },
-    onSuccess: () => {
+    onSuccess: (data, { photoId }) => {
+      const { albumId } = data
       const queryClient = getQueryClient()
       queryClient.invalidateQueries({ queryKey: ["getAlbums"] })
+
+      if (photoId) {
+        patchPhotoAlbum({ photoId, defaultAlbumId: albumId })
+      }
+
+      router.push(`/album/${albumId}`)
     },
     throwOnError: true,
   })


### PR DESCRIPTION
## 작업 내용

### 🚨 버그 현상

앨범 생성 페이지에서 앨범 생성시, 앨범이 2개씩 생성되는 버그 발생

<br/>

### 🐞 버그 원인

앨범 생성하는 query인 postAlbum의 onSuccess에서 실행되는 콜백함수와
postAlbum 이후에 작성된 코드들이 동기적으로 실행되지 않아서 발생하던 문제.

<br/>

### ✅ 해결 방법

postAlbum 이후에 실행되어야 하는 코드들 (앨범 상세 페이지로의 routing) 코드를
onSuccess 콜백 함수 안으로 넣어줌.

<br/>

## 🎸 기타 사항

### 👀 앞으로 예상되는 문제

이 방법은 현재 서비스에선 문제가 없으나 **앞으로 걱정되는 문제가 하나 있음.**
지금 방식의 코드는 앨범 생성 후 무조건 앨범 상세 페이지로의 routing을 유발하기 때문에
유연성이 높은 코드라고 보기 어려움.

**따라서 onSuccess의 콜백함수와, 그 이후에 작성된 코드들이 순서대로 실행될 수 있도록 하면서도
유연성을 유지할 수 있는 방법에 대해 고민해보면 좋을 것 같음.**

<br/>