### PR TITLE
[feat/NEWME-104] 바텀바 아이콘 수정

### DIFF
--- a/src/app/album/[id]/_component/ImageDetail.tsx
+++ b/src/app/album/[id]/_component/ImageDetail.tsx
@@ -4,6 +4,7 @@ import Image from "next/image"
 import { useState } from "react"
 import Slider from "react-slick"
 
+import { myFetch } from "@/app/api/myfetch"
 import Icon from "@/common/Icon"
 import SquareButton from "@/common/SquareButton"
 import { fullDateStr } from "@/utils"
@@ -33,16 +34,17 @@ export const ImageDetail = ({
     initialSlide: startIdx,
   }
   const handleDownload = async (imageUrl: string) => {
-    const res = await fetch(imageUrl, {
+    const res = await myFetch(imageUrl, {
       method: "GET",
-      mode: "no-cors",
+      headers: {
+        "Content-Type": "image/jpeg",
+      },
     })
-    const blob = await res.blob()
 
-    const url = URL.createObjectURL(blob)
+    const url = URL.createObjectURL(res)
     const a = document.createElement("a")
     a.href = url
-    a.download = `mafoo_${fullDateStr()}.jpg` // 다운로드될 파일명 설정
+    a.download = `mafoo_${fullDateStr()}.jpg`
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)

--- a/src/app/api/myfetch/customFetch.ts
+++ b/src/app/api/myfetch/customFetch.ts
@@ -121,8 +121,14 @@ const customFetch =
         fetchProvided
       )
 
-      const responseText = await interceptedResponse.text()
-      return responseText ? JSON.parse(responseText) : {}
+      const contentType = response.headers.get("Content-Type")
+
+      if (contentType && contentType.includes("image/")) {
+        return await response.blob()
+      } else {
+        const responseText = await interceptedResponse.text()
+        return responseText ? JSON.parse(responseText) : {}
+      }
     }
 
     return await response.json()

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,11 +22,11 @@ export const metadata: Metadata = {
   openGraph: {
     title: "마푸 - 지금 함께 찍은 네컷사진을 올려보세요",
     description: "마푸를 켜고 QR을 가져다 대면 바로 업로드",
-    url: process.env.NEXT_PUBLIC_OPENGRAPH_URL,
+    url: process.env.NEXT_PUBLIC_URL,
     type: "website",
     siteName: "마푸",
   },
-  metadataBase: new URL(process.env.NEXT_PUBLIC_METADATABASE!),
+  metadataBase: new URL(process.env.NEXT_PUBLIC_URL as string),
   icons: { icon: "/images/favicon.png" },
 }
 

--- a/src/common/BottomBar.tsx
+++ b/src/common/BottomBar.tsx
@@ -55,7 +55,7 @@ const Scanner = () => {
       <Link href="/album">
         <Button className="rounded-lg" tabIndex={-1}>
           <div className={TAB_ITEM_CLASSNAME}>
-            <Icon name="userCircleOutline" size={28} color="gray-400" />
+            <Icon name="albumBold" size={28} color="gray-400" />
             <span>내 앨범</span>
           </div>
         </Button>
@@ -83,7 +83,7 @@ const Profile = () => {
       <Link href="/album">
         <Button className="rounded-lg" tabIndex={-1}>
           <div className={TAB_ITEM_CLASSNAME}>
-            <Icon name="userCircleOutline" size={28} color="gray-400" />
+            <Icon name="albumOutline" size={28} color="gray-400" />
             <span>내 앨범</span>
           </div>
         </Button>


### PR DESCRIPTION
## 🛠 작업 내용

- 바텀바 하단 영역 아이콘 변경
- 이미지 다운로드 기능에서 `no-cors` 옵션 제거
- customFetch에서 Image 파일 사용할 수 있게 정의

이미지 다운로드시 no-cors 설정으로 인한 빈 데이터 문제로 다운로드되지 않는 문제 해결

이미지 blob타입도 반환값으로 정의할 수 있게 custmFetch 로직 수정



## 👀 참고 문서

- [지라티켓](https://3spinachpasta.atlassian.net/browse/MAFOO-104)

## 🖼 스크린샷

<img width="410" alt="image" src="https://github.com/user-attachments/assets/abdd035e-9d43-403a-8ec9-29cba7c77ba4">

## 🎸 기타 사항
