### PR TITLE
fix: Authorization 옵션 제거

### DIFF
--- a/src/app/album/[id]/_component/ImageDetail.tsx
+++ b/src/app/album/[id]/_component/ImageDetail.tsx
@@ -38,6 +38,7 @@ export const ImageDetail = ({
       method: "GET",
       headers: {
         "Content-Type": "image/jpeg",
+        Authorization: "null",
       },
     })
 

--- a/src/app/api/myfetch/index.ts
+++ b/src/app/api/myfetch/index.ts
@@ -18,6 +18,11 @@ export const myFetch = customFetch({
 
       if (accessToken && options) {
         const headers = new Headers(options.headers || {})
+
+        if (headers.get("Authorization") === "null") {
+          return [url, options]
+        }
+
         headers.set("Authorization", `Bearer ${accessToken}`)
         options.headers = headers
       }


### PR DESCRIPTION
Authorization가 있는 경우 인증이 필요한 경우로 인식해서 cors 문제 발생

## 🛠 작업 내용

- 이미지 다운로드 문제 해결

문제 원인 : custom fetch 로직은 header에 authorization 옵션이 들어갑니다
이미지 URL에 fetch 요청을 보낼 때 Authorization 헤더에 토큰 정보가 포함되면 403 에러가 발생하는 이유는 서버에서 해당 요청을 인증된 요청으로 간주하고, 이미지 리소스에 대한 접근을 제한하거나 거부하기 때문일 가능성이 있습니다.
해당 이미지 서버는 s3로 cors 에러가 발생하고 있습니다. 따라서 Authorization 제거해줍니다.

CORS (Cross-Origin Resource Sharing): 만약 이미지 서버와 API 서버가 다른 도메인에서 운영되고 있다면, CORS 정책이 문제가 될 수 있습니다. 인증 헤더가 있는 요청에 대해 CORS 정책이 적용되어, 서버가 이를 허용하지 않아서 403 에러를 반환할 수 있습니다.

## 👀 참고 문서

- [지라티켓](https://3spinachpasta.atlassian.net/browse/MAFOO-114)

## 🖼 스크린샷

<img width="858" alt="image" src="https://github.com/user-attachments/assets/8cf32ac8-9f68-4af1-a441-6b83302a908c">

## 🎸 기타 사항
