### PR TITLE
fix: 정규표현식 예외케이스

### DIFF
--- a/src/libs/index.ts
+++ b/src/libs/index.ts
@@ -15,9 +15,18 @@ export const FOUR_CUT_BRAND = {
   PICDOT: "https://picdot.kr",
 }
 
-// 객체의 value들을 정규표현식 패턴으로 변환
+// 정규식을 변환할 때 백슬래시 이스케이프 문제를 해결하고,
+// 각 URL에 대해 개별적으로 전체 매칭이 되도록 ^와 $를 추가
 const urlPatterns = Object.values(FOUR_CUT_BRAND)
-  .map((url) => url.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&") + ".*")
+  .map((url) => {
+    // HARUFILM과 같은 정규식 패턴을 포함한 URL 처리
+    if (url.includes("\\d")) {
+      return url.replace(/\\\\/g, "\\") // HARUFILM과 같이 이미 이스케이프된 정규식을 복원
+    } else {
+      return url.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&") // 다른 URL은 이스케이프 처리
+    }
+  })
+  .map((url) => `^${url}.*$`) // 각 URL에 대해 시작과 끝에 ^, $ 추가
   .join("|")
 
 export const isUrlIncluded = (input: string) =>

--- a/src/libs/index.ts
+++ b/src/libs/index.ts
@@ -1,7 +1,6 @@
 // 하루 필름인 경우는 지점별 도메인이 가변적
 // HARUFILM: "http://haru{숫자}.mx{숫자}.co.kr",
-
-export const FOUR_CUT_BRAND = {
+export const FOUR_CUT_BRAND: Record<string, string> = {
   PHOTOISM: "https://qr.seobuk.kr",
   DONTLXXKUP: "https://x.dontlxxkup.kr",
   HARUFILM: "http://haru\\d+\\.mx\\d+\\.co\\.kr",
@@ -15,22 +14,18 @@ export const FOUR_CUT_BRAND = {
   PICDOT: "https://picdot.kr",
 }
 
-// 정규식을 변환할 때 백슬래시 이스케이프 문제를 해결하고,
-// 각 URL에 대해 개별적으로 전체 매칭이 되도록 ^와 $를 추가
-const urlPatterns = Object.values(FOUR_CUT_BRAND)
-  .map((url) => {
-    // HARUFILM과 같은 정규식 패턴을 포함한 URL 처리
-    if (url.includes("\\d")) {
-      return url.replace(/\\\\/g, "\\") // HARUFILM과 같이 이미 이스케이프된 정규식을 복원
-    } else {
-      return url.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&") // 다른 URL은 이스케이프 처리
-    }
-  })
-  .map((url) => `^${url}.*$`) // 각 URL에 대해 시작과 끝에 ^, $ 추가
+// HARUFILM 키를 제외하고 다른 URL들을 처리
+const urlPatterns = Object.keys(FOUR_CUT_BRAND)
+  .filter((key) => key !== "HARUFILM")
+  .map(
+    (key) =>
+      FOUR_CUT_BRAND[key].replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&") + ".*"
+  )
+  .concat([FOUR_CUT_BRAND.HARUFILM]) // HARUFILM을 이스케이프 없이 추가
   .join("|")
 
 export const isUrlIncluded = (input: string) =>
-  new RegExp(`^(${urlPatterns})$`).test(input)
+  new RegExp(`^(${urlPatterns})`).test(input)
 
 // 외부 링크 확인 정규 표현식
 export const isExternalLink = (url: string) => {


### PR DESCRIPTION
## 🛠 작업 내용

- 브랜드 url 정규표현식 수정

## 🎸 기타 사항
`HARUFILM: "http://haru\\d+\\.mx\\d+\\.co\\.kr",` 하루 필름인 경우 정규표현식을 정의해놨는데, 기존 urlPatterns에서 치환하는 과정에서 d+가 이상하게 치환이 됨. 따라서 이미 정규표현식으로 정의된 도메인은 제외하고 정규표현식으로 바꾸게하는 식으로 분기 작업 진행
