### PR TITLE
[feat/recap] 리캡 이미지내에 앨범 및 날짜 정보추가

### DIFF
--- a/src/app/album/[id]/_component/AlbumPhotos.tsx
+++ b/src/app/album/[id]/_component/AlbumPhotos.tsx
@@ -131,7 +131,11 @@ export const AlbumPhotos = ({ albumInfo }: AlbumPhotosProps) => {
             "-t",
             "1", // 각 이미지를 1초 동안 표시
             "-vf",
-            "scale=390:670,format=yuv420p", // 이미지 크기를 1920x1080으로 변환
+            "scale=390:670,format=yuv420p", // 이미지 크기를 390x670으로 변환
+            "-c:v",
+            "libx264", // 코덱을 설정 (H.264 코덱)
+            "-b:v",
+            "2M", // 비디오 비트레이트를 2Mbps로 설정 (화질을 높이기 위해 비트레이트를 높게 설정)
             "-y",
             `video${index}.mp4`
           )

--- a/src/app/album/[id]/_component/AlbumPhotos.tsx
+++ b/src/app/album/[id]/_component/AlbumPhotos.tsx
@@ -11,7 +11,7 @@ import Button from "@/common/Button"
 import Icon from "@/common/Icon"
 import { base64ToBlob, blobToFile } from "@/utils"
 
-import { PhotoInfo } from "../../types"
+import { AlbumInfo, PhotoInfo } from "../../types"
 import { ImageDetail } from "./ImageDetail"
 import { Photo } from "./Photo"
 import { PhotoAddButton } from "./PhotoAddButton"
@@ -20,7 +20,13 @@ import VideoRecap from "./VideoRecap"
 
 const ffmpeg = createFFmpeg({ log: true })
 
-export const AlbumPhotos = ({ albumId }: { albumId: string }) => {
+interface AlbumPhotosProps {
+  albumInfo: AlbumInfo
+}
+
+export const AlbumPhotos = ({ albumInfo }: AlbumPhotosProps) => {
+  const { showAlert } = useAlertStore()
+
   const [photos, setPhotos] = useState<PhotoInfo[]>([])
   const [imageDetailShown, setImageDetailShown] = useState(false)
 
@@ -54,14 +60,14 @@ export const AlbumPhotos = ({ albumId }: { albumId: string }) => {
 
   useEffect(() => {
     const fetchAlbums = async () => {
-      const data = await getPhotos(albumId)
+      const data = await getPhotos(albumInfo.albumId)
       if (data.length) {
         setPhotos(data)
       }
     }
 
     fetchAlbums()
-  }, [albumId])
+  }, [albumInfo.albumId])
 
   useEffect(() => {
     const generateImages = async () => {
@@ -159,13 +165,13 @@ export const AlbumPhotos = ({ albumId }: { albumId: string }) => {
     }
 
     createVideo()
-  }, [files])
+  }, [files, showAlert])
 
   return (
     <>
       <div className="flex w-full flex-wrap p-4 px-6">
         <Masonry columnsCount={2} gutter="12px">
-          <PhotoAddButton albumId={albumId} />
+          <PhotoAddButton albumId={albumInfo.albumId} />
           {photos.map((photo, idx) => (
             <div key={photo.photoId} onClick={() => onPhotoClick(idx)}>
               <Photo photo={photo} />

--- a/src/app/album/[id]/_component/AlbumPhotos.tsx
+++ b/src/app/album/[id]/_component/AlbumPhotos.tsx
@@ -9,6 +9,9 @@ import Masonry from "react-responsive-masonry"
 import { deletePhoto, getPhotos } from "@/app/api/photo"
 import Button from "@/common/Button"
 import Icon from "@/common/Icon"
+import { ICON_COLOR_STYLE, ICON_NAME } from "@/constants"
+import { formattedDate } from "@/libs"
+import { useAlertStore } from "@/store/alert"
 import { base64ToBlob, blobToFile } from "@/utils"
 
 import { AlbumInfo, PhotoInfo } from "../../types"
@@ -187,10 +190,10 @@ export const AlbumPhotos = ({ albumInfo }: AlbumPhotosProps) => {
           />
         )}
 
-        {photos.length >= 2 && (
+        {photos.length >= 3 && (
           <Button
             onClick={() => setIsCreateRecap(true)}
-            className="bg-lightgray m-auto rounded-[100px] bg-[114deg] bg-slate-400 bg-gradient-to-br from-[#C680FF] via-[#F09BF2] to-[#FF82C6] bg-[length:100px_100px] bg-repeat p-14 px-[22px] py-[16px] bg-blend-overlay shadow-[0_16px_20px_0_rgba(101,125,159,0.12),0_0_8px_0_rgba(88,100,117,0.08)]">
+            className="bg-lightgray m-auto rounded-[100px] bg-gradient-to-r from-purple-400 via-pink-300 to-pink-500 p-14 px-[22px] py-[16px]">
             <div className="flex gap-1 align-middle">
               <p>리캡 만들기</p>
               <Icon name="reelOutline" size={24} color="white" />
@@ -200,7 +203,7 @@ export const AlbumPhotos = ({ albumInfo }: AlbumPhotosProps) => {
       </div>
 
       <div className="fixed left-0 top-0 -translate-x-full">
-        {photos.map(({ photoUrl }, idx) => (
+        {photos.map(({ photoUrl, createdAt }, idx) => (
           <div
             className="relative inline-block"
             key={`${photoUrl}-${idx}`}
@@ -220,6 +223,32 @@ export const AlbumPhotos = ({ albumInfo }: AlbumPhotosProps) => {
               fill
               alt={`recap_bg_img-${idx}`}
             />
+            <div className="absolute bottom-[31px] w-full">
+              <div className="flex items-center justify-around">
+                <div
+                  style={{
+                    backgroundColor: `rgba(255, 255, 255, 0.70)`,
+                  }}
+                  className="tp-title2-semibold b flex h-11 w-28 items-center justify-center gap-1 rounded-[100px] px-4 py-2 text-gray-800">
+                  <Icon
+                    name={ICON_NAME[albumInfo.type]}
+                    color={ICON_COLOR_STYLE[albumInfo.type]}
+                    size={28}
+                  />
+                  {albumInfo.name}
+                </div>
+                <span
+                  className="text-right text-[18px] font-normal leading-[130%] tracking-[0.36px]"
+                  style={{
+                    color: `var(--White, #FFF)`,
+                    fontFeatureSettings: `'ss10' on`,
+                    fontFamily: `"SB AggroOTF"`,
+                    fontStyle: `normal`,
+                  }}>
+                  {formattedDate(createdAt)}
+                </span>
+              </div>
+            </div>
           </div>
         ))}
       </div>

--- a/src/app/album/[id]/_component/Header.tsx
+++ b/src/app/album/[id]/_component/Header.tsx
@@ -1,9 +1,8 @@
 "use client"
 
 import { useRouter } from "next/navigation"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
-import { getAlbum } from "@/app/api/photo"
 import { deleteAlbum } from "@/app/api/photo"
 import Icon from "@/common/Icon"
 import { ICON_COLOR_STYLE, ICON_NAME } from "@/constants"
@@ -13,8 +12,11 @@ import { cn } from "@/utils"
 import { AlbumInfo } from "../../types"
 import { Dialog } from "./Dialog"
 
-export const Header = ({ albumId }: { albumId: string }) => {
-  const [album, setAlbum] = useState<AlbumInfo | null>(null)
+interface HeaderProps {
+  albumInfo: AlbumInfo
+}
+
+export const Header = ({ albumInfo }: HeaderProps) => {
   const [isModalShown, setIsModalShown] = useState(false)
   const router = useRouter()
 
@@ -26,44 +28,34 @@ export const Header = ({ albumId }: { albumId: string }) => {
   }
 
   const handleDeleteAlbum = async () => {
-    await deleteAlbum(album!.albumId)
+    await deleteAlbum(albumInfo.albumId)
     router.push("/album")
   }
 
   const dialogProps = {
-    title: `'${album?.name}' 앨범을 삭제할까요?`,
+    title: `'${albumInfo.name}' 앨범을 삭제할까요?`,
     desc: "모든 사진도 함께 삭제되며, 복구할 수 없어요",
     confirmBtnContext: "앨범 삭제",
     onClose: onDialogCloseClick,
     onConfirm: handleDeleteAlbum,
   }
 
-  useEffect(() => {
-    const initAlbum = async (albumId: string) => {
-      const data = await getAlbum(albumId)
-      if (data) {
-        setAlbum(() => data)
-      }
-    }
-    initAlbum(albumId)
-  }, [albumId])
-
-  if (!album) {
+  if (!albumInfo) {
     return <header className={cn(headerVariants())}></header>
   }
 
   return (
-    <header className={cn(headerVariants({ type: album.type }))}>
-      <button onClick={() => router.push("/album")}>
+    <header className={cn(headerVariants({ type: albumInfo.type }))}>
+      <button onClick={() => router.push("/albumInfo")}>
         <Icon name="altArrowLeftOutline" size={28} />
       </button>
       <div className="tp-title2-semibold flex gap-1 text-gray-800">
         <Icon
-          name={ICON_NAME[album.type]}
-          color={ICON_COLOR_STYLE[album.type]}
+          name={ICON_NAME[albumInfo.type]}
+          color={ICON_COLOR_STYLE[albumInfo.type]}
           size={28}
         />
-        {album.name}
+        {albumInfo.name}
       </div>
       <button
         className="tp-body1-regular text-red-600"

--- a/src/app/album/[id]/_component/VideoLoading.tsx
+++ b/src/app/album/[id]/_component/VideoLoading.tsx
@@ -2,7 +2,7 @@ import Image from "next/image"
 
 const VideoLoading = () => {
   return (
-    <div className="absolute left-0 top-0 z-10 h-[100vh] w-full bg-gray-800 bg-opacity-50">
+    <div className="absolute left-0 top-0 z-10 h-dvh w-full bg-gray-800 bg-opacity-50">
       <div
         role="status"
         className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transform">

--- a/src/app/album/[id]/_component/VideoRecap.tsx
+++ b/src/app/album/[id]/_component/VideoRecap.tsx
@@ -2,8 +2,8 @@
 
 import Button from "@/common/Button"
 import Icon from "@/common/Icon"
-import SquareButton from "@/common/SquareButton"
-import { useAlertStore } from "@/store/alert"
+// import SquareButton from "@/common/SquareButton"
+// import { useAlertStore } from "@/store/alert"
 import { fullDateStr } from "@/utils"
 
 interface VideoRecapProps {
@@ -11,7 +11,7 @@ interface VideoRecapProps {
 }
 
 const VideoRecap = ({ url }: VideoRecapProps) => {
-  const { showAlert } = useAlertStore()
+  // const { showAlert } = useAlertStore()
 
   const handleDownload = () => {
     const a = document.createElement("a")
@@ -23,37 +23,37 @@ const VideoRecap = ({ url }: VideoRecapProps) => {
     URL.revokeObjectURL(url) // Object URL 해제
   }
 
-  const handleShare = async () => {
-    if (!navigator.canShare) {
-      showAlert("공유하기를 지원하지 않는 브라우저입니다.")
-    }
+  // const handleShare = async () => {
+  //   if (!navigator.canShare) {
+  //     showAlert("공유하기를 지원하지 않는 브라우저입니다.")
+  //   }
 
-    try {
-      await navigator.share({
-        title: "MDN",
-        text: "Learn web development on MDN!",
-        url,
-      })
-    } catch (err) {
-      showAlert("공유하기에 실패했습니다.")
-    }
-  }
+  //   try {
+  //     await navigator.share({
+  //       title: "MDN",
+  //       text: "Learn web development on MDN!",
+  //       url,
+  //     })
+  //   } catch (err) {
+  //     showAlert("공유하기에 실패했습니다.")
+  //   }
+  // }
 
   return (
     <div className="fixed left-0 top-0 z-10 h-dvh w-dvw justify-center overflow-auto bg-gray-900">
       <div className="m-auto flex h-dvh w-full max-w-[390px] flex-col justify-between">
         <video className="mt-8" src={url} autoPlay controls></video>
 
-        <div className="flex gap-3">
+        <div className="mb-5 flex gap-3">
           <Button
             onClick={handleDownload}
             color="white"
-            className="flex w-full items-center justify-center gap-[6px] rounded-[100px] bg-gray-800 px-6 text-white">
+            className="flex h-14 w-full items-center justify-center gap-[6px] rounded-[100px] bg-gray-800 px-6 text-white">
             <Icon name="downloadBold" size={28} color="white" />
             <span className="mr-[6px]">다운로드 받기</span>
           </Button>
 
-          <SquareButton
+          {/* <SquareButton
             onClick={handleShare}
             className="w-full rounded-[100px] bg-gray-800 bg-gradient-to-br from-yellow-500 via-pink-500 to-blue-500"
             style={{
@@ -62,7 +62,7 @@ const VideoRecap = ({ url }: VideoRecapProps) => {
             }}>
             <Icon name="insta" size={28} color="white" />
             <span className="mr-[6px]">인스타 공유</span>
-          </SquareButton>
+          </SquareButton> */}
         </div>
       </div>
     </div>

--- a/src/app/album/[id]/page.tsx
+++ b/src/app/album/[id]/page.tsx
@@ -1,15 +1,33 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { getAlbum } from "@/app/api/photo"
+
+import { AlbumInfo } from "../types"
 import { AlbumPhotos } from "./_component/AlbumPhotos"
 import { Header } from "./_component/Header"
 
 const AlbumDetailPage = ({ params }: { params: { id: string } }) => {
   const { id } = params
+  const [albumInfo, setAlbumInfo] = useState<AlbumInfo>()
+
+  useEffect(() => {
+    const initAlbum = async () => {
+      const data = await getAlbum(id)
+      if (data) {
+        setAlbumInfo(data)
+      }
+    }
+    initAlbum()
+  }, [id])
+
+  if (!albumInfo) return
 
   return (
     <>
-      <Header albumId={id} />
-      {/* <section className="flex w-full flex-wrap p-4 px-6"> */}
-      <AlbumPhotos albumId={id} />
-      {/* </section> */}
+      <Header albumInfo={albumInfo} />
+      <AlbumPhotos albumInfo={albumInfo} />
     </>
   )
 }

--- a/src/app/album/types/index.ts
+++ b/src/app/album/types/index.ts
@@ -20,6 +20,8 @@ export interface PhotoInfo {
   photoId: string
   photoUrl: string
   albumId: string
+  brand: string
+  createdAt: string
 }
 
 export interface AlbumInfo {

--- a/src/app/api/photo.ts
+++ b/src/app/api/photo.ts
@@ -1,4 +1,4 @@
-import { AlbumInfo, AlbumType } from "../album/types"
+import { AlbumInfo, AlbumType, PhotoInfo } from "../album/types"
 import { myFetch } from "./myfetch"
 
 export interface PostQrCodeResponse {
@@ -19,11 +19,7 @@ export const postQrCode = async (
   return data
 }
 
-type GetPhotosResponse = {
-  photoId: string
-  photoUrl: string
-  albumId: string
-}[]
+type GetPhotosResponse = PhotoInfo[]
 
 export const getPhotos = async (
   albumId: string

--- a/src/libs/index.ts
+++ b/src/libs/index.ts
@@ -53,3 +53,16 @@ const getUserAgent = () => {
 export const isWebView = () => RegExp(WEBVIEW_USER_AGENT).test(getUserAgent())
 export const isAndroid = () => RegExp(ANDROID_USER_AGENT).test(getUserAgent())
 export const isIOS = () => RegExp(IOS_USER_AGENT).test(getUserAgent())
+
+// yyyy-MM-dd 형식의 날짜를 Date 객체로 변환
+export const formattedDate = (date: string) => {
+  const newDate = new Date(date)
+
+  // 연도, 월, 일을 추출
+  const year = newDate.getFullYear()
+  const month = String(newDate.getMonth() + 1).padStart(2, "0") // 월은 0부터 시작하므로 +1
+  const day = String(newDate.getDate()).padStart(2, "0")
+
+  // YYYY-MM-DD 형식으로 반환
+  return `${year}-${month}-${day}`
+}


### PR DESCRIPTION
## 🛠 작업 내용

- 리캡 이미지에 들어가는 이미지 날짜와 앨범 정보를 추가했습니다.

## 🖼 스크린샷

![image](https://github.com/user-attachments/assets/03cc06c6-8ba6-48f8-bea3-40c9d72bf28e)
