### PR TITLE
feat: 리캡 미리만들기 (서비스워커에서 수행)

### DIFF
--- a/src/app/album/[id]/_component/AlbumPhotos.tsx
+++ b/src/app/album/[id]/_component/AlbumPhotos.tsx
@@ -12,7 +12,6 @@ import Button from "@/common/Button"
 import Icon from "@/common/Icon"
 import { ICON_COLOR_STYLE, ICON_NAME } from "@/constants"
 import { formattedDate } from "@/libs"
-import { useAlertStore } from "@/store/alert"
 import { recapColorVariants } from "@/styles/variants"
 import { cn } from "@/utils"
 
@@ -31,7 +30,6 @@ interface AlbumPhotosProps {
 }
 
 export const AlbumPhotos = ({ albumInfo }: AlbumPhotosProps) => {
-  const { showAlert } = useAlertStore()
   const { profile } = useGetProfile()
 
   const [photos, setPhotos] = useState<PhotoInfo[]>([])
@@ -106,10 +104,10 @@ export const AlbumPhotos = ({ albumInfo }: AlbumPhotosProps) => {
       setFiles(filteredImages)
     }
 
-    if (isRecapOpen) {
+    if (photos.length >= 3) {
       generateImages()
     }
-  }, [refs, isRecapOpen])
+  }, [refs, photos.length])
 
   useEffect(() => {
     if (!files.length) return
@@ -178,7 +176,7 @@ export const AlbumPhotos = ({ albumInfo }: AlbumPhotosProps) => {
     }
 
     createVideo()
-  }, [files, showAlert])
+  }, [files])
 
   return (
     <>


### PR DESCRIPTION
## 🛠 작업 내용

- 리캡 만드는 시간이 오래 걸리는 문제로 인해 앨범에 진입시 이미지가 3장있을 경우 미리 리캡 만들기. 동영상으로 변환 작업은 별도 스레드인 서비스 워커에서 만들어지므로 현재 서비스에는 영향이 없습니다.

## 👀 참고 문서

- [지라](https://3spinachpasta.atlassian.net/browse/MAFOO-135)

